### PR TITLE
Added model and parsing for market page response

### DIFF
--- a/steam-api-logic/src/main/java/com/steamext/steam/api/logic/client/http/parser/MarketPageHTMLParser.java
+++ b/steam-api-logic/src/main/java/com/steamext/steam/api/logic/client/http/parser/MarketPageHTMLParser.java
@@ -1,44 +1,87 @@
 package com.steamext.steam.api.logic.client.http.parser;
 
 import com.steamext.steam.api.logic.exceptions.SteamHttpClientException;
-import com.steamext.steam.api.model.requestmodel.UserPageInfo;
+import com.steamext.steam.api.model.responsemodel.MarketRestriction;
+import com.steamext.steam.api.model.responsemodel.MarketRestrictions;
+import com.steamext.steam.api.model.responsemodel.StartMarketPageResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 
 @Data
 @Slf4j
-public class MarketPageHTMLParser implements SteamHTMLParser<String> {
+public class MarketPageHTMLParser implements SteamHTMLParser<StartMarketPageResponse> {
     @Override
-    public String parseHTML(InputStream html) throws SteamHttpClientException {
+    public StartMarketPageResponse parseHTML(InputStream html) throws SteamHttpClientException {
+        StartMarketPageResponse response = new StartMarketPageResponse();
         try {
             Document doc = Jsoup.parse(html, StandardCharsets.UTF_8.name(),
                     "steamcommunity.com");
 
-//            user.setUsername(getUsername(doc));
-//            user.setRealname(getRealName(doc));
-//            user.setAddress(getAddress(doc));
-//            user.setLevel(getLevel(doc));
+            MarketRestrictions restrictions = getAllRestrictions(doc);
+            response.setRestrictions(restrictions);
 
-            return doc.html();
-
+            return response;
         } catch (IOException e) {
             throw new SteamHttpClientException(e);
         }
+    }
 
-//        return (T) user;
-//        StringWriter sw = new StringWriter();
-//        try {
-//            IOUtils.copy(html, sw);
-//        } catch (IOException e) {
-//            e.printStackTrace();
-//        }
+    private MarketRestrictions getAllRestrictions(Document doc) {
+        MarketRestrictions restrictions;
+        Element marketRestrictionElements = doc.selectFirst("ul.market_restrictions");
+        if (marketRestrictionElements != null) {
+            restrictions = getAllRestrictionsFromRestrictionsContainer(marketRestrictionElements);
+        } else {
+            restrictions = new MarketRestrictions();
+        }
+        return restrictions;
+    }
+
+    private MarketRestrictions getAllRestrictionsFromRestrictionsContainer(Element restrictionsContainer) {
+        MarketRestrictions marketRestrictions = new MarketRestrictions();
+
+        Elements restrictionItems = restrictionsContainer.select("li");
+        if (restrictionItems != null) {
+            for (Element restrictionItem : restrictionItems) {
+                MarketRestriction restriction = getRestrictionFromElement(restrictionItem);
+                marketRestrictions.getRestrictions().add(restriction);
+            }
+        }
+
+        return marketRestrictions;
+    }
+
+    private MarketRestriction getRestrictionFromElement(Element restrictionElement) {
+        MarketRestriction restriction = null;
+        String restrictionHelpLink = getRestrictionHelpLink(restrictionElement);
+        String restrictionText = restrictionElement.text();
+        if (restrictionHelpLink != null || restrictionText != null) {
+            restriction = new MarketRestriction();
+            restriction.setRestrictionHelpLink(restrictionHelpLink);
+            restriction.setRestrictionText(restrictionText);
+        }
+        return restriction;
+    }
+
+    private String getRestrictionHelpLink(Element restrictionElement) {
+        String restrictionHelpLink = null;
+        if (restrictionElement != null) {
+            Element a = restrictionElement.selectFirst("a");
+            if (a != null) {
+                String href = a.attr("href");
+                if (href != null) {
+                    restrictionHelpLink = href;
+                }
+            }
+        }
+        return restrictionHelpLink;
     }
 }

--- a/steam-api-logic/src/test/java/com/steamext/steam/api/logic/client/http/SteamHttpClientIT.java
+++ b/steam-api-logic/src/test/java/com/steamext/steam/api/logic/client/http/SteamHttpClientIT.java
@@ -13,6 +13,7 @@ import com.steamext.steam.api.model.requestmodel.UserCredentials;
 import com.steamext.steam.api.model.requestmodel.UserLoginInfo;
 import com.steamext.steam.api.model.requestmodel.UserPageInfo;
 import com.steamext.steam.api.model.responsemodel.RsaDataContainer;
+import com.steamext.steam.api.model.responsemodel.StartMarketPageResponse;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,11 +85,11 @@ public class SteamHttpClientIT {
     @Test
     @Order(4)
     public void testGettingMarketPage() throws SteamHttpClientException {
-        String marketPage = client.execute(new GetMarketPageSteamHttpRequest(),
+        StartMarketPageResponse response = client.execute(new GetMarketPageSteamHttpRequest(),
                 new MarketPageHTMLParser());
 
 
-        assertNotNull(marketPage);
-        assertTrue(marketPage.contains((String) properties.getData().get("it.username")));
+        assertNotNull(response);
+//        assertTrue(marketPage.contains((String) properties.getData().get("it.username")));
     }
 }

--- a/steam-api-model/src/main/java/com/steamext/steam/api/model/responsemodel/MarketRestriction.java
+++ b/steam-api-model/src/main/java/com/steamext/steam/api/model/responsemodel/MarketRestriction.java
@@ -1,0 +1,11 @@
+package com.steamext.steam.api.model.responsemodel;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketRestriction {
+    private String restrictionText;
+    private String restrictionHelpLink;
+}

--- a/steam-api-model/src/main/java/com/steamext/steam/api/model/responsemodel/MarketRestrictions.java
+++ b/steam-api-model/src/main/java/com/steamext/steam/api/model/responsemodel/MarketRestrictions.java
@@ -1,0 +1,13 @@
+package com.steamext.steam.api.model.responsemodel;
+
+import lombok.Data;
+import lombok.NonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Data
+public class MarketRestrictions {
+    @NonNull
+    private Collection<MarketRestriction> restrictions = new ArrayList<>();
+}

--- a/steam-api-model/src/main/java/com/steamext/steam/api/model/responsemodel/StartMarketPageResponse.java
+++ b/steam-api-model/src/main/java/com/steamext/steam/api/model/responsemodel/StartMarketPageResponse.java
@@ -1,0 +1,8 @@
+package com.steamext.steam.api.model.responsemodel;
+
+import lombok.Data;
+
+@Data
+public class StartMarketPageResponse {
+    private MarketRestrictions restrictions;
+}


### PR DESCRIPTION
Added response model for getting start market page. Now parser extracts market restrictions from page. Every market restriction has two fields: restriction text (e.g. "You must have a valid Steam purchase...") and restriction link (e.g. ".../kb_article.php?ref=..."). Response model contains non-null list of restrictions, every restriction contains at least one field which is not null.